### PR TITLE
terraform bootstrap module v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# terraform-s3-backend
-Terraform S3 backend module (with DynamoDB locking)
+# terraform-bootstrap
+Terraform bootstrap module, adds s3 state store, with dynamodb locking and uses KMS to encrypt s3 state files.

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,36 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "enforce_tls" {
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    effect = "Deny"
+
+    actions = [
+      "s3:*",
+    ]
+
+    resources = [
+      aws_s3_bucket.state.arn,
+      "${aws_s3_bucket.state.arn}/*",
+    ]
+
+    condition {
+      test = "Bool"
+      values = [
+        "false"
+      ]
+      variable = "aws:SecureTransport"
+    }
+    condition {
+      test = "NumericLessThan"
+      values = [
+        "1.2"
+      ]
+      variable = "s3:TlsVersion"
+    }
+  }
+}

--- a/dynamodb.tf
+++ b/dynamodb.tf
@@ -1,0 +1,18 @@
+resource "aws_dynamodb_table" "state_locking_table" {
+  name           = local.name
+  read_capacity  = 10
+  write_capacity = 10
+  hash_key       = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  ttl {
+    attribute_name = "TimeToExist"
+    enabled        = false
+  }
+
+  tags = local.tags
+}

--- a/kms.tf
+++ b/kms.tf
@@ -1,0 +1,10 @@
+resource "aws_kms_key" "tf_bootstrap" {
+  description             = "Terraform Bootstrap KMS Key"
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+}
+
+resource "aws_kms_alias" "tf_bootstrap" {
+  name          = "alias/tf-bootstrap-key"
+  target_key_id = aws_kms_key.tf_bootstrap.key_id
+}

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,6 @@
 locals {
-  name = "terraform-state-${var.unique_id}-${data.aws_caller_identity.current.account_id}"
-}
+  name = "${var.unique_id}-${data.aws_caller_identity.current.account_id}-tfstate"
 
+  # module_tags = var.enable_tags_module ? module.external_tagging.tags : {}
+  tags = merge({ Name = local.name }, var.tags)
+}

--- a/main.tf
+++ b/main.tf
@@ -1,39 +1,16 @@
-data "aws_caller_identity" "current" {}
-
 terraform {
-  required_version = ">= 0.12"
-}
+  required_version = ">= 1.3.0"
 
-resource "aws_s3_bucket" "state_bucket" {
-  bucket = local.name
-  # acl    = "private"
-
-  #versioning {
-  #  enabled = true
-  #}
-
-  tags = {
-    Name = local.name
+  required_providers {
+    aws   = ">= 3.59.0"
+    local = ">= 1.4"
   }
 }
 
-resource "aws_dynamodb_table" "state_locking_table" {
-  name           = local.name
-  read_capacity  = 10
-  write_capacity = 10
-  hash_key       = "LockID"
+#module "external_tagging" {
+#  count  = var.enable_tags_module ? 1 : 0
+#  source = "https://github.com/vamegh/terraform-tags.git?ref=v1.0.0"
+#
+#  tags = var.tags
+#}
 
-  attribute {
-    name = "LockID"
-    type = "S"
-  }
-
-  ttl {
-    attribute_name = "TimeToExist"
-    enabled        = false
-  }
-
-  tags = {
-    Name = local.name
-  }
-}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,40 @@
-output "state_bucket_name" {
-  value = "${aws_s3_bucket.state_bucket.id}"
+output "kms_alias_arn" {
+  value       = aws_kms_alias.tf_bootstrap.arn
+  description = "KMS Terraform bootstrap key alias ARN"
 }
 
-output "state_table_name" {
-  value = "${aws_dynamodb_table.state_locking_table.id}"
+output "kms_key_arn" {
+  value       = aws_kms_key.tf_bootstrap.arn
+  description = "KMS Terraform bootstrap key ARN"
+}
+
+output "s3_bucket_arn" {
+  value       = aws_s3_bucket.state.arn
+  description = "Terraform S3 state bucket ARN"
 }
 
 output "state_table_arn" {
-  value = "${aws_dynamodb_table.state_locking_table.arn}"
+  value       = aws_dynamodb_table.state_locking_table.arn
+  description = "Terraform DynamoDB ARN"
 }
+
+output "kms_alias_name" {
+  value       = aws_kms_alias.tf_bootstrap.name
+  description = "KMS Terraform boostrap key alias name"
+}
+
+output "kms_key_name" {
+  value       = aws_kms_key.tf_bootstrap.key_id
+  description = "KMS Terraform bootstrap key name/id"
+}
+
+output "state_bucket_name" {
+  value       = aws_s3_bucket.state.id
+  description = "Terraform S3 state bucket name"
+}
+
+output "state_table_name" {
+  value       = aws_dynamodb_table.state_locking_table.id
+  description = "Terraform DynamoDB table name"
+}
+

--- a/s3.tf
+++ b/s3.tf
@@ -1,0 +1,37 @@
+resource "aws_s3_bucket" "state" {
+  bucket = local.name
+  tags   = local.tags
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "state" {
+  bucket = aws_s3_bucket.state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = aws_kms_key.tf_bootstrap.arn
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "state" {
+  bucket = aws_s3_bucket.state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_policy" "enforce_tls" {
+  count  = var.enable_tls ? 1 : 0
+  bucket = aws_s3_bucket.state.id
+  policy = data.aws_iam_policy_document.enforce_tls.json
+}
+
+resource "aws_s3_bucket_logging" "state" {
+  count  = length(var.logging_bucket) > 1 ? 1 : 0
+  bucket = aws_s3_bucket.state.id
+
+  target_bucket = var.logging_bucket
+  target_prefix = "log/${local.name}/"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -2,3 +2,25 @@ variable "unique_id" {
   type    = string
   default = ""
 }
+
+variable "logging_bucket" {
+  type    = string
+  default = ""
+}
+
+variable "enable_tls" {
+  type    = bool
+  default = true
+}
+
+variable "enable_tags_module" {
+  description = "Enable the external tagging module"
+  type        = bool
+  default     = false
+}
+
+variable "tags" {
+  description = "Optional custom resource tags"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
renamed from s3_backend to bootstrap, more appropriate name.

split resources into own files.

added kms encryption to s3

updated s3 bucket creation, to work with newer aws provider, which requires multiple resources.

updated to work with terraform v1.30+ (any version after v1.3 which supports optionals)

	modified:   README.md
	new file:   data.tf
	new file:   dynamodb.tf
	new file:   kms.tf
	modified:   locals.tf
	modified:   main.tf
	modified:   outputs.tf
	new file:   s3.tf
	modified:   variables.tf